### PR TITLE
Fix "npm run lint" and "npm run tsc" :

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,13 +31,16 @@
     "@angular/forms": "2.4.5",
     "@angular/platform-browser": "2.4.5",
     "@angular/platform-server": "2.4.5",
+    "codelyzer": "3.0.0-beta.0",
+    "rxjs": "5.0.1",
+    "tslint": "4.5.1",
+    "typescript": "2.0.2",
+    "zone.js": "0.7.2",
     "@types/es6-shim": "0.31.32",
     "@types/jasmine": "2.5.40",
-    "@types/lodash": "4.14.39",
-    "codelyzer": "3.0.0-beta.3",
-    "rxjs": "5.2.0",
-    "tslint": "4.5.1",
-    "typescript": "2.2.1",
-    "zone.js": "0.7.2"
+    "@types/lodash": "4.14.39"
+  },
+  "engines": {
+    "node": ">=0.8.0"
   }
 }

--- a/src/help.service.ts
+++ b/src/help.service.ts
@@ -11,7 +11,7 @@ export class HelpService {
     this.edcClient = new EdcClient('/doc/');
   }
 
-  getHelp(primaryKey: string, subKey:string): Promise<Helper> {
+  getHelp(primaryKey: string, subKey: string): Promise<Helper> {
     return this.edcClient.getHelper(primaryKey, subKey);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14,14 +14,6 @@
     minimist "^1.2.0"
     reflect-metadata "^0.1.2"
 
-"@angular/compiler-cli@^4.0.0-rc.1":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/compiler-cli/-/compiler-cli-4.0.0-rc.2.tgz#49730cb232d48aba25d68541eb9166bf5330dd2b"
-  dependencies:
-    "@angular/tsc-wrapped" "4.0.0-rc.2"
-    minimist "^1.2.0"
-    reflect-metadata "^0.1.2"
-
 "@angular/compiler@2.4.5":
   version "2.4.5"
   resolved "https://registry.yarnpkg.com/@angular/compiler/-/compiler-2.4.5.tgz#521da325e2e002398e8f9de52cfb03d303729e72"
@@ -49,12 +41,6 @@
   resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-0.5.1.tgz#7a69bec999eef41903dddaaccdc862cfcface52c"
   dependencies:
     tsickle "^0.2"
-
-"@angular/tsc-wrapped@4.0.0-rc.2":
-  version "4.0.0-rc.2"
-  resolved "https://registry.yarnpkg.com/@angular/tsc-wrapped/-/tsc-wrapped-4.0.0-rc.2.tgz#d7023d93f4576b6f776ffc7175ff760e7e133705"
-  dependencies:
-    tsickle "^0.21.0"
 
 "@ng-bootstrap/ng-bootstrap@^1.0.0-alpha.20":
   version "1.0.0-alpha.20"
@@ -153,15 +139,13 @@ code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
 
-codelyzer@3.0.0-beta.3:
-  version "3.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-3.0.0-beta.3.tgz#ed0e968817279c2eecc9b023a8193ea97be5278a"
+codelyzer@3.0.0-beta.0:
+  version "3.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/codelyzer/-/codelyzer-3.0.0-beta.0.tgz#3debea2cb7b3c0a12e1e85e45c1d53a80a71e28d"
   dependencies:
-    "@angular/compiler-cli" "^4.0.0-rc.1"
     app-root-path "^2.0.1"
     css-selector-tokenizer "^0.7.0"
     cssauron "^1.4.0"
-    ngast "^0.0.6"
     semver-dsl "^1.0.1"
     source-map "^0.5.6"
     sprintf-js "^1.0.3"
@@ -221,8 +205,8 @@ cssesc@^0.1.0:
   resolved "https://registry.yarnpkg.com/cssesc/-/cssesc-0.1.0.tgz#c814903e45623371a0477b40109aaafbeeaddbb4"
 
 debug@^2.2.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.1.tgz#79855090ba2c4e3115cc7d8769491d58f0491351"
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.2.tgz#dfa96a861ee9b8c2f29349b3bcc41aa599a71e0f"
   dependencies:
     ms "0.7.2"
 
@@ -464,10 +448,6 @@ ms@0.7.2:
   version "0.7.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-0.7.2.tgz#ae25cf2512b3885a1d95d7f037868d8431124765"
 
-ngast@^0.0.6:
-  version "0.0.6"
-  resolved "https://registry.yarnpkg.com/ngast/-/ngast-0.0.6.tgz#6dd1e29ad01363f4cd709b8e66b325eeb9e6af9e"
-
 npm-run-path@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/npm-run-path/-/npm-run-path-1.0.0.tgz#f5c32bf595fe81ae927daec52e82f8b000ac3c8f"
@@ -581,9 +561,9 @@ resolve@^1.1.7:
   dependencies:
     path-parse "^1.0.5"
 
-rxjs@5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.2.0.tgz#db537de8767c05fa73721587a29e0085307d318b"
+rxjs@5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-5.0.1.tgz#3a69bdf9f0ca0a986303370d4708f72bdfac8356"
   dependencies:
     symbol-observable "^1.0.1"
 
@@ -685,15 +665,6 @@ tsickle@^0.2:
     source-map "^0.5.6"
     source-map-support "^0.4.2"
 
-tsickle@^0.21.0:
-  version "0.21.5"
-  resolved "https://registry.yarnpkg.com/tsickle/-/tsickle-0.21.5.tgz#341c1834b9d293c8cbffc295a86a1e46268ed22f"
-  dependencies:
-    minimist "^1.2.0"
-    mkdirp "^0.5.1"
-    source-map "^0.5.6"
-    source-map-support "^0.4.2"
-
 tslint@4.5.1:
   version "4.5.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-4.5.1.tgz#05356871bef23a434906734006fc188336ba824b"
@@ -709,12 +680,12 @@ tslint@4.5.1:
     update-notifier "^2.0.0"
 
 tsutils@^1.1.0:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.2.2.tgz#7e165c601367b9f89200b97ff47d9e38d1a6e4c8"
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/tsutils/-/tsutils-1.3.0.tgz#dd86cb304f7a2e86c012deade2f8d0f886f57808"
 
-typescript@2.2.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.2.1.tgz#4862b662b988a4c8ff691cc7969622d24db76ae9"
+typescript@2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.0.2.tgz#a63f848074498a4dfa7f293afda0835d501d9540"
 
 unique-string@^1.0.0:
   version "1.0.0"
@@ -778,8 +749,8 @@ xdg-basedir@^3.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
 yallist@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.0.0.tgz#306c543835f09ee1a4cb23b7bce9ab341c91cdd4"
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.0.tgz#3a0f3b45f42cb60f822c92f69ade2bb88beb1ae0"
 
 zone.js@0.7.2:
   version "0.7.2"


### PR DESCRIPTION
- Set version to match versions from "generator-angular2-library".
- Add missing space in HelpService to satisfy tslint.