### PR TITLE
[CONF] Fix outDir property on tsconfig.json.

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": "",
-    "declaration": false,
+    "declaration": true,
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,9 +11,8 @@
     "mapRoot": "./",
     "module": "es2015",
     "moduleResolution": "node",
-    "outDir": "../dist",
+    "outDir": "dist",
     "sourceMap": true,
-    "declaration": true,
     "target": "es5",
     "typeRoots": [
       "node_modules/@types"


### PR DESCRIPTION
On yarn build, dist folder was created above the project folder.
+ Remove duplicate key.