### PR TITLE
[EDC-512] Help window not resizable and not scrollable on IE11 & Firefox.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "edc-popover-ng",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Angular Help Component for edc - TECH'advantage",
   "angular-cli": {},
   "scripts": {

--- a/src/help.component.spec.ts
+++ b/src/help.component.spec.ts
@@ -94,7 +94,7 @@ describe('Help component', () => {
         component.goToArticle(1);
 
         // then window.open() should be called
-        expect(window.open).toHaveBeenCalledWith(url, 'help', 'height=800,width=1200');
+        expect(window.open).toHaveBeenCalledWith(url, 'help', 'scrollbars=1,resizable=1,height=800,width=1200');
       });
     });
 
@@ -116,7 +116,7 @@ describe('Help component', () => {
         component.goToLink(link);
 
         // then window.open() should be called
-        expect(window.open).toHaveBeenCalledWith(url, 'help', 'height=800,width=1200');
+        expect(window.open).toHaveBeenCalledWith(url, 'help', 'scrollbars=1,resizable=1,height=800,width=1200');
       });
 
     });

--- a/src/help.component.ts
+++ b/src/help.component.ts
@@ -91,6 +91,6 @@ export class HelpComponent implements OnInit {
   }
 
   private open(url: string) {
-    window.open(url, 'help', 'height=800,width=1200');
+    window.open(url, 'help', 'scrollbars=1,resizable=1,height=800,width=1200');
   }
 }


### PR DESCRIPTION
 When calling window.open(), add "scrollbars" and "resizable" specs for IE11 and Firefox.

https://www.w3schools.com/jsref/met_win_open.asp